### PR TITLE
Fix yarn update - Take 2

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,7 +12,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PUSH_TOKEN }}
-          # submodules: recursive
+      - name: Init submodules
+        run: git submodule update --depth 1 --init --recursive --remote
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -21,6 +22,7 @@ jobs:
         run: yarn
       - name: "Update"
         run: yarn update
+        continue-on-error: true
       - name: "Print git status"
         run: git status
       - name: "Print git diff"

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function run() {
     }
   }
 
-  console.log(`Update all ${uniqueRepoFullNames.size} git submodules`);
+  console.log(`Updating all ${uniqueRepoFullNames.size} git submodules...`);
   await execFile('git', ['submodule', 'update', '--depth', '1', "--recursive", '--remote'], {
     cwd: 'libraries'
   });


### PR DESCRIPTION
The repo is not properly initialized when it's cloned inside the update workflow, so running `yarn update` has no effect.

I'm running `git submodule update --depth 1 --init --recursive --remote` here to initialize the submodules before we run any other operation