### PR TITLE
Update access_token

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.PUSH_TOKEN }}
           submodules: recursive
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This is to fix the push issue back to the repo due to access issue.

Reverted it my change to use `Personal Access Token` instead of `Github Token`.