### PR TITLE
Pull latest commits from libraries

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function run() {
   });
 
   console.log(`Updating all ${uniqueRepoFullNames.size} git submodules...`);
-  await execFile('git', ['submodule', 'update', '--depth', '1', "--recursive", '--init', '--force'], {
+  await execFile('git', ['submodule', 'update', '--depth', '1', '--init', '--force', '--remote'], {
     cwd: 'libraries'
   });
   console.log('Done!');


### PR DESCRIPTION
The current scripts fails in updating the libraries because there are some of them with submodules that fails to be updated. We generally don't need to update the submodules of React Native libraries, as we are more interested in the code written by our contributors and the git submodules they use are usually third party dependencies.

For example. react-native-skia depends on the skia submodule, which was causing a failure in the updating script.

This change make sure that we don't recursively update the submodules (we don't need them) and it pulls the latest commits from the remote repositories.